### PR TITLE
Allow /company-users/mine with plain login

### DIFF
--- a/src/Spryker/Glue/CompanyUsersRestApi/Processor/CompanyUser/CompanyUserReader.php
+++ b/src/Spryker/Glue/CompanyUsersRestApi/Processor/CompanyUser/CompanyUserReader.php
@@ -74,6 +74,12 @@ class CompanyUserReader implements CompanyUserReaderInterface
      */
     public function getCompanyUserByResourceId(RestRequestInterface $restRequest): RestResponseInterface
     {
+        $idResource = $restRequest->getResource()->getId();
+
+        if ($idResource === CompanyUsersRestApiConfig::COLLECTION_IDENTIFIER_CURRENT_USER) {
+            return $this->getCompanyUsersByCustomerReference($restRequest);
+        }
+
         $idCompany = $restRequest->getRestUser()->getIdCompany();
         if (!$idCompany) {
             return $this->companyUserRestResponseBuilder->createCompanyUserNotSelectedErrorResponse();
@@ -81,12 +87,6 @@ class CompanyUserReader implements CompanyUserReaderInterface
 
         if (!$this->can('SeeCompanyUsersPermissionPlugin')) {
             return $this->companyUserRestResponseBuilder->createCompanyUserHasNoPermissionErrorResponse();
-        }
-
-        $idResource = $restRequest->getResource()->getId();
-
-        if ($idResource === CompanyUsersRestApiConfig::COLLECTION_IDENTIFIER_CURRENT_USER) {
-            return $this->getCompanyUsersByCustomerReference($restRequest);
         }
 
         return $this->getCompanyUser($idResource, $restRequest);


### PR DESCRIPTION
## PR Description
In case you have only one company user for your customer, when using the /access-tokens endpoint you'll retrieve the company user id alongside with the access token.
 
When there is more than one company user assigned to the current customer and by project design there is no default, you'll retrieve null as company user id. I assume this happens by design as the system cannot know, which company you logged in for.

However this gives you a problem when you want to select a company: You need a list of possible companyUserIds to proceed. The /company-users/mine request can help you, but it requires, that you already retrieved a token from the /company-user-access-tokens endpoint.

So it would make sense to allow the /company-users/mine endpoint to work with a plain token. Not sure, if there are good reasons from your side to disallow.

Update: Even if you happen to have a default company user there is still a problem with the request flow. You will have to:

1. Retrieve a token from /access-tokens
2. Retrieve another token from /company-users-access-tokens
3. Fetch the company users via /company-users/mine
4. User selects a company user different from the default
5. Retrieve yet another token from /company-users-access-tokens

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
